### PR TITLE
Added English as default landing page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,8 +21,9 @@ extra:
   palette:
     primary: 'cyan'
   social:
-  - icon: 'fontawesome/brands/github-alt'
-    link: 'https://github.com/hzi-braunschweig/SORMAS-Glossary'
+  - icon: 'fontawesome/brands/github-alt'    
+    link: 'https://hzi-braunschweig.github.io/SORMAS-Glossary/en/'
+    
 plugins:
 - search:
     separator: '[\s]+'


### PR DESCRIPTION
The initial landing page of link: https://hzi-braunschweig.github.io/SORMAS-Glossary/ was broken after adding language configs